### PR TITLE
Add Cache to RaspNodeSim

### DIFF
--- a/raspnodesim/src/main/java/net/ctdata/raspnodesim/RaspNodeSim.java
+++ b/raspnodesim/src/main/java/net/ctdata/raspnodesim/RaspNodeSim.java
@@ -3,6 +3,9 @@ package net.ctdata.raspnodesim;
 import net.ctdata.raspnodesim.config.CliOptions;
 import net.ctdata.raspnodesim.config.NodeConfiguration;
 import net.ctdata.raspnodesim.datacollection.CollectionThread;
+import net.ctdata.raspnodesim.observationcache.CacheListener;
+import net.ctdata.raspnodesim.observationcache.MemoryCache;
+import net.ctdata.raspnodesim.observationcache.ObservationCache;
 import net.ctdata.raspnodesim.router.ConsoleListener;
 import net.ctdata.raspnodesim.router.DataRouter;
 import net.ctdata.raspnodesim.websocket.RaspNodeServer;
@@ -40,11 +43,14 @@ public class RaspNodeSim {
 
         DataRouter router = new DataRouter();
 
-        RaspNodeServer websocketServer = new RaspNodeServer();
+        ObservationCache cache = new MemoryCache();
+
+        RaspNodeServer websocketServer = new RaspNodeServer(cache);
         websocketServer.start();
 
         router.AddListener(new ConsoleListener());
         router.AddListener(websocketServer);
+        router.AddListener(new CacheListener(cache));
 
         Thread collectionThread = new Thread(new CollectionThread(configuration, router));
         collectionThread.start();

--- a/raspnodesim/src/main/java/net/ctdata/raspnodesim/observationcache/CacheListener.java
+++ b/raspnodesim/src/main/java/net/ctdata/raspnodesim/observationcache/CacheListener.java
@@ -1,0 +1,17 @@
+package net.ctdata.raspnodesim.observationcache;
+
+import net.ctdata.common.Messages.Observation;
+import net.ctdata.raspnodesim.router.DataListener;
+
+public class CacheListener implements DataListener {
+    final ObservationCache cache;
+
+    public CacheListener(ObservationCache cache){
+        this.cache = cache;
+    }
+
+    @Override
+    public void NewObservation(Observation observation) {
+        cache.AddObservation(observation);
+    }
+}

--- a/raspnodesim/src/main/java/net/ctdata/raspnodesim/observationcache/MemoryCache.java
+++ b/raspnodesim/src/main/java/net/ctdata/raspnodesim/observationcache/MemoryCache.java
@@ -1,0 +1,63 @@
+package net.ctdata.raspnodesim.observationcache;
+
+import net.ctdata.common.Messages.Observation;
+import net.ctdata.raspnodesim.router.DataListener;
+import org.joda.time.DateTime;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+
+public class MemoryCache implements ObservationCache {
+    private HashMap<ObservationKey, Observation> observations = new HashMap<ObservationKey, Observation>();
+
+    class ObservationKey {
+        int sensor;
+        DateTime time;
+
+        ObservationKey(int sensor, DateTime time){
+            this.sensor = sensor;
+            this.time = time;
+        }
+
+        ObservationKey(Observation observation){
+            this.sensor = observation.getSensor();
+            this.time = observation.getTime();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ObservationKey that = (ObservationKey) o;
+
+            if (sensor != that.sensor) return false;
+            return !(time != null ? !time.equals(that.time) : that.time != null);
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = sensor;
+            result = 31 * result + (time != null ? time.hashCode() : 0);
+            return result;
+        }
+    }
+
+    @Override
+    public void AddObservation(Observation observation) {
+        observations.put(new ObservationKey(observation), observation);
+    }
+
+    @Override
+    public void GetObservations(DataListener listener) {
+        LinkedList<Observation> observationList = new LinkedList<Observation>(observations.values());
+        for (Observation observation : observationList)
+            listener.NewObservation(observation);
+    }
+
+    @Override
+    public void DeleteObservation(int sensor, DateTime time) {
+        observations.remove(new ObservationKey(sensor,time));
+    }
+}

--- a/raspnodesim/src/main/java/net/ctdata/raspnodesim/observationcache/ObservationCache.java
+++ b/raspnodesim/src/main/java/net/ctdata/raspnodesim/observationcache/ObservationCache.java
@@ -1,0 +1,11 @@
+package net.ctdata.raspnodesim.observationcache;
+
+import net.ctdata.common.Messages.Observation;
+import net.ctdata.raspnodesim.router.DataListener;
+import org.joda.time.DateTime;
+
+public interface ObservationCache {
+    void AddObservation(Observation observation);
+    void GetObservations(DataListener listener);
+    void DeleteObservation(int sensor, DateTime time);
+}


### PR DESCRIPTION
I've been thinking, I think we specified the raspberry node should be able to store its observations locally, but I guess in-memory is fine for our demo deployment. We'd only need a new implementation of the ObservationCache interface if we want SQLite / JSON storage / whatever. What do you think?
