### PR TITLE
Add sensor number to Metadata message

### DIFF
--- a/raspnodesim/src/main/java/net/ctdata/raspnodesim/sensors/AbstractSensor.java
+++ b/raspnodesim/src/main/java/net/ctdata/raspnodesim/sensors/AbstractSensor.java
@@ -32,6 +32,7 @@ public abstract class AbstractSensor implements Sensor {
         sensorMetadata.setLongitude(getLongitude());
         sensorMetadata.setLatitude(getLatitude());
         sensorMetadata.setName(getName());
+        sensorMetadata.setSensor(getNumber());
         return sensorMetadata;
     }
 


### PR DESCRIPTION
I guess I forgot about this earlier. This fixes the 'duplicate primary key' issue you've been seeing.
